### PR TITLE
Hotfix/fix findbytitle

### DIFF
--- a/src/main/java/com/moomark/post/configuration/profile/BaseProfileCondition.java
+++ b/src/main/java/com/moomark/post/configuration/profile/BaseProfileCondition.java
@@ -1,0 +1,25 @@
+package com.moomark.post.configuration.profile;
+
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+public abstract class BaseProfileCondition implements Condition {
+
+  @Override
+  public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+    String[] activeProfile = context.getEnvironment().getActiveProfiles();
+    List<Profile> targetProfiles = this.getTargetProfile();
+
+    return Arrays.stream(activeProfile)
+        .anyMatch(e -> this.isActiveProfileMatchedWithTargetProfiles(e, targetProfiles));
+  }
+
+  abstract List<Profile> getTargetProfile();
+
+  private boolean isActiveProfileMatchedWithTargetProfiles(String activeProfile, List<Profile> targetProfile) {
+    return targetProfile.stream().anyMatch(e -> e.isEqualTo(activeProfile));
+  }
+}

--- a/src/main/java/com/moomark/post/configuration/profile/LocalProfileCondition.java
+++ b/src/main/java/com/moomark/post/configuration/profile/LocalProfileCondition.java
@@ -1,0 +1,11 @@
+package com.moomark.post.configuration.profile;
+
+import java.util.List;
+
+public class LocalProfileCondition extends BaseProfileCondition{
+
+  @Override
+  List<Profile> getTargetProfile() {
+    return List.of(Profile.LOCAL);
+  }
+}

--- a/src/main/java/com/moomark/post/configuration/profile/Profile.java
+++ b/src/main/java/com/moomark/post/configuration/profile/Profile.java
@@ -1,0 +1,18 @@
+package com.moomark.post.configuration.profile;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Profile {
+  LOCAL("local"),
+  DEVELOP("dev"),
+  PROD("prod");
+
+  private final String value;
+
+  public boolean isEqualTo(String profile) {
+    return this.value.equals(profile);
+  }
+}

--- a/src/main/java/com/moomark/post/repository/PostRepository.java
+++ b/src/main/java/com/moomark/post/repository/PostRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.moomark.post.model.entity.Post;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-  public List<Post> findByTitle(String title);
+  public List<Post> findByTitleContaining(String title);
 
   public List<Post> findByUserId(String userId);
 

--- a/src/main/java/com/moomark/post/service/PostService.java
+++ b/src/main/java/com/moomark/post/service/PostService.java
@@ -56,11 +56,8 @@ public class PostService {
 
   public Post getPost(Long id) {
     Optional<Post> post = postRepository.findById(id);
-    if (post.isEmpty()) {
-      return null;
-    }
+    return post.orElse(null);
 
-    return post.get();
   }
 
   public void deletePost(Long postId) throws JpaException {

--- a/src/main/java/com/moomark/post/service/PostService.java
+++ b/src/main/java/com/moomark/post/service/PostService.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.domain.Sort.Order;
@@ -78,7 +77,7 @@ public class PostService {
   }
 
   public List<PostDto> getPostInfoByTitle(String title) {
-    var postList = postRepository.findByTitle(title);
+    var postList = postRepository.findByTitleContaining(title);
     List<PostDto> postDtoList = new ArrayList<>();
     for (Post post : postList) {
       var postDto = PostDto.builder().id(post.getId()).title(post.getTitle()).userId(post.getUserId())

--- a/src/test/java/com/moomark/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/moomark/post/repository/PostRepositoryTest.java
@@ -1,0 +1,47 @@
+package com.moomark.post.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.moomark.post.model.entity.Post;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+class PostRepositoryTest {
+
+  @Autowired
+  private PostRepository postRepository;
+
+  @Test
+  void findByTitle() {
+    // given
+    Post firstSavedData = Post.builder()
+        .title("FIRST TITLE")
+        .content("FIRST CONTENT")
+        .userId("FIRST USER ID")
+        .build();
+
+    Post secondSavedData = Post.builder()
+        .title("SECOND TITLE")
+        .content("SECOND CONTENT")
+        .userId("SECOND USER ID")
+        .build();
+
+    // when
+    postRepository.save(firstSavedData);
+    postRepository.save(secondSavedData);
+
+    // then
+    List<Post> savedList = postRepository.findByTitleContaining("TITLE");
+    Assertions.assertThat(savedList).hasSize(2);
+  }
+}

--- a/src/test/java/com/moomark/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/moomark/post/repository/PostRepositoryTest.java
@@ -44,4 +44,34 @@ class PostRepositoryTest {
     List<Post> savedList = postRepository.findByTitleContaining("TITLE");
     Assertions.assertThat(savedList).hasSize(2);
   }
+
+  @Test
+  void findByUserId() {
+
+    //given
+    Post firstSavedData = Post.builder()
+        .title("FIRST TITLE")
+        .content("FIRST CONTENT")
+        .userId("FIRST USER ID")
+        .build();
+    Post secondSavedData = Post.builder()
+        .title("SECOND TITLE")
+        .content("SECOND CONTENT")
+        .userId("SECOND USER ID")
+        .build();
+    Post thirdSavedData = Post.builder()
+        .title("THIRD TITLE")
+        .content("THIRD CONTENT")
+        .userId("FIRST USER ID")
+        .build();
+
+    //when
+    postRepository.save(firstSavedData);
+    postRepository.save(secondSavedData);
+    postRepository.save(thirdSavedData);
+
+    //then
+    List<Post> savedList = postRepository.findByUserId("FIRST USER ID");
+    Assertions.assertThat(savedList).hasSize(2);
+  }
 }


### PR DESCRIPTION
## 변경 사항
기존의 `findByTitle` 함수가 예상하는 방식(제목에 글자가 포함된 내용을 전부 조회) 처럼 동작하지 않아 내용을 수정